### PR TITLE
Fix typo in Antibody title

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Also features the `macos_is_dark` helper function to determine if the macOS dark
 antigen bundle pndurette/zsh-lux   # in your ~/.zshrc
 ```
 
-**[Antiboy](https://github.com/getantibody/antibody)**
+**[Antibody](https://github.com/getantibody/antibody)**
 
 ```bash
 antibody bundle pndurette/zsh-lux   # in your ~/.zshrc


### PR DESCRIPTION
Not sure about the diff on the license line, this is from the Github web editor. 😄 