### PR TITLE
Add support for Dynamic Desktop pictures

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-2022 Pierre-Nick Durette
+Copyright (c) 2019-2022 Pierre Nicolas Durette
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Pierre-Nick Durette
+Copyright (c) 2019-2022 Pierre-Nick Durette
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Also features the `macos_is_dark` helper function to determine if the macOS dark
    * [Usage](#usage)
        * [lux](#lux)
        * [macos_is_dark](#macos_is_dark)
+       * [macos_release_name](#macos_release_name)
        * [Debug mode](#debug-mode)
    * [Items](#items)
        * [macos](#macos)
@@ -105,6 +106,19 @@ if macos_is_dark; then
 else
     echo "macOS is light!"
 fi
+```
+
+#### `macos_release_name`
+
+Helper function that provides the release name of macOS (e.g. "Catalina")
+
+Example usage:
+
+```bash
+$ sw_vers -productVersion
+10.15.7
+$ macos_release_name
+Catalina
 ```
 
 #### Debug mode

--- a/README.md
+++ b/README.md
@@ -255,9 +255,9 @@ An item is represented by one function that can trigger an appearance change for
 
 **Extra configuration**:
 
-| Setting                              | Variable       | Default                                    | Customizable |
-| ------------------------------------ | -------------- | ------------------------------------------ | ------------ |
-| Array of the items affected by `all` | `LUX_ALL_LIST` | `( macos macos_desktop iterm_all vscode )` | ✅            |
+| Setting                              | Variable       | Default                                                      | Customizable |
+| ------------------------------------ | -------------- | :----------------------------------------------------------- | ------------ |
+| Array of the items affected by `all` | `LUX_ALL_LIST` | `( macos macos_desktop macos_desktop_style iterm_all vscode )` | ✅            |
 
 ------
 
@@ -325,4 +325,4 @@ alias nox='lux all dark'
 
 ## License
 
-[The MIT License (MIT)](LICENSE) Copyright © 2019 Pierre Nicolas Durette
+[The MIT License (MIT)](LICENSE) Copyright © 2019-2022 Pierre Nicolas Durette

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Also features the `macos_is_dark` helper function to determine if the macOS dark
    * [Items](#items)
        * [macos](#macos)
        * [macos_desktop](#macos_desktop)
+       * [macos_desktop_style](#macos_desktop_style)
        * [iterm](#iterm)
        * [iterm_all](#iterm_all)
        * [vscode](#vscode)
@@ -110,15 +111,15 @@ fi
 
 #### `macos_release_name`
 
-Helper function that provides the release name of macOS (e.g. "Catalina")
+Helper function that returns the capitalized release name of macOS (e.g. "Monterey")
 
 Example usage:
 
 ```bash
 $ sw_vers -productVersion
-10.15.7
+12.6
 $ macos_release_name
-Catalina
+Monterey
 ```
 
 #### Debug mode
@@ -148,16 +149,37 @@ An item is represented by one function that can trigger an appearance change for
 
 #### `macos_desktop`
 
-**Action**: Sets macOS desktop picture
+**Action**: Sets macOS desktop picture. On Mojave and above, _Dynamic_ and _Light and Dark_ Desktop pictures are special `.heic` files that contain multiple images that macOS can [automatically change throughout the day](https://support.apple.com/en-ca/guide/mac-help/mchlp3013/12.0/mac/12.0). For those desktop pictures, set the same path for both `light` and `dark` and use [macos_desktop_style](#macos_desktop_style) to choose the appearance setting.
+
+*Note:* Only the `<macOS name> Graphic.heic` (e.g. `Ventura Graphic.heic`) Dynamic Desktop comes pre-installed. To use other images than the default (below), select the image in System Preferences which will download it to `~/Library/Application Support/com.apple.mobileAssetDesktop/`
 
 **Requires**: macOS
 
 **Modes**:
 
-| Mode    | Variable                  | Default                                      | Customizable |
-| ------- | ------------------------- | -------------------------------------------- | ------------ |
-| `light` | `LUX_MACOS_DESKTOP_LIGHT` | `/Library/Desktop Pictures/Mojave Day.jpg`   | ✅            |
-| `dark`  | `LUX_MACOS_DESKTOP_DARK`  | `/Library/Desktop Pictures/Mojave Night.jpg` | ✅            |
+| Mode    | Variable                  | Default                                                      | Customizable |
+| ------- | ------------------------- | ------------------------------------------------------------ | ------------ |
+| `light` | `LUX_MACOS_DESKTOP_LIGHT` | `/System/Library/Desktop Pictures/<macOS name> Graphic.heic` | ✅            |
+| `dark`  | `LUX_MACOS_DESKTOP_DARK`  | ``/System/Library/Desktop Pictures/<macOS name> Graphic.heic`` | ✅            |
+
+**Extra configuration**: N/A
+
+---
+
+#### `macos_desktop_style`
+
+**Action**: Sets macOS desktop picture _style_, for certain `.heic` images (in Mojave and above) that support it. Supported image types are either "Dynamic Desktop" (`dynamic`, image changes throughout the day) or "Light and Dark" (`auto`, image matches the macOS apperance). Either types can be expliclty set to their `light` or `dark` setting).
+
+**Requires**: macOS
+
+**Modes**:
+
+| Mode      | Variable                          | Default   | Customizable |
+| --------- | --------------------------------- | --------- | ------------ |
+| `light`   | `LUX_MACOS_DESKTOP_STYLE_LIGHT`   | `light`   | 🚫            |
+| `dark`    | `LUX_MACOS_DESKTOP_STYLE_DARK`    | `dark`    | 🚫            |
+| `auto`    | `LUX_MACOS_DESKTOP_STYLE_AUTO`    | `auto`    | 🚫            |
+| `dynamic` | `LUX_MACOS_DESKTOP_STYLE_DYNAMIC` | `dynamic` | 🚫            |
 
 **Extra configuration**: N/A
 

--- a/zsh-lux.plugin.zsh
+++ b/zsh-lux.plugin.zsh
@@ -309,7 +309,7 @@ LUX_ALL_LIGHT='light'
 LUX_ALL_DARK='dark'
 
 function _lux_set_all() {
-    _lux_defined LUX_ALL_LIST || LUX_ALL_LIST=( macos macos_desktop iterm_all vscode )
+    _lux_defined LUX_ALL_LIST || LUX_ALL_LIST=( macos macos_desktop macos_desktop_style iterm_all vscode )
     for item in $LUX_ALL_LIST; do
         lux $item $1 &
     done

--- a/zsh-lux.plugin.zsh
+++ b/zsh-lux.plugin.zsh
@@ -131,7 +131,9 @@ function macos_release_name() {
     declare -A _lux_macos_release_names=(
         "10.14" "Mojave"
         "10.15" "Catalina"
-        "11.0"  "Big Sur"
+        "11"    "Big Sur"
+        "12"    "Monterey"
+        "13"    "Ventura"
     )
     local macos_version=$(sw_vers -productVersion)
     local macos_release=$_lux_macos_release_names[${macos_version%.*}]
@@ -169,21 +171,50 @@ function _lux_set_macos() {
 # Element: 'macos_desktop'
 # Action: Sets macOS desktop picture
 # Default modes:
-#  * 'light': '/Library/Desktop Pictures/Mojave Day.jpg'
-#  * 'dark': '/Library/Desktop Pictures/Mojave Night.jpg'
+#  * 'light': '/System/Library/Desktop Pictures/$(macos_release_name) Graphic.heic'
+#  * 'dark': '/System/Library/Desktop Pictures/$(macos_release_name) Graphic.heic'
 # Extra configuration: N/A
 # Requires:
 #  * macOS
 
-_lux_default LUX_MACOS_DESKTOP_LIGHT '/Library/Desktop Pictures/Mojave Day.jpg'
-_lux_default LUX_MACOS_DESKTOP_DARK  '/Library/Desktop Pictures/Mojave Night.jpg'
+_lux_default LUX_MACOS_DESKTOP_LIGHT "/System/Library/Desktop Pictures/$(macos_release_name) Graphic.heic"
+_lux_default LUX_MACOS_DESKTOP_DARK  "/System/Library/Desktop Pictures/$(macos_release_name) Graphic.heic"
 
-function _lux_set_macos_desktop {
+function _lux_set_macos_desktop() {
     if ! _lux_is_macos; then return 1; fi
     osascript -l JavaScript <<- EOF
         desktops = Application('System Events').desktops()
         for (d in desktops) {
             desktops[d].picture = '$1'
+        }
+EOF
+}
+
+#-----------------------------------------
+# Element: 'macos_desktop_style'
+# Action: Sets macOS desktop picture style (for pictures that support it)
+# Default modes:
+#  * 'light': 'light'
+#  * 'dark': 'dark'
+#  * 'auto': 'auto'
+#  * 'dynamic': 'dynamic'
+# Extra configuration: N/A
+# Requires:
+#  * macOS
+
+LUX_MACOS_DESKTOP_STYLE_LIGHT="light"
+LUX_MACOS_DESKTOP_STYLE_DARK="dark"
+LUX_MACOS_DESKTOP_STYLE_AUTO="auto"
+LUX_MACOS_DESKTOP_STYLE_DYNAMIC="dynamic"
+
+LUX_MACOS_DESKTOP_STYLE_EXTRAS="auto dynamic"
+
+function _lux_set_macos_desktop_style() {
+    if ! _lux_is_macos; then return 1; fi
+    osascript -l JavaScript <<- EOF
+        desktops = Application('System Events').desktops()
+        for (d in desktops) {
+            desktops[d].dynamicStyle = '$1'
         }
 EOF
 }

--- a/zsh-lux.plugin.zsh
+++ b/zsh-lux.plugin.zsh
@@ -123,6 +123,25 @@ function macos_is_dark() {
     fi
 }
 
+# macos_release_name: get the release name of macOS
+# * Echos the capitalized release name of macOS
+#   (e.g. "Catalina" for macOS 10.15.*)
+
+function macos_release_name() {
+    declare -A _lux_macos_release_names=(
+        "10.14" "Mojave"
+        "10.15" "Catalina"
+        "11.0"  "Big Sur"
+    )
+    local macos_version=$(sw_vers -productVersion)
+    local macos_release=$_lux_macos_release_names[${macos_version%.*}]
+
+    _lux_log "fct: $funcstack[1]" "macOS version: $macos_version" \
+                                  "macOS release: $macos_release"
+
+    echo $macos_release
+}
+
 #-----------------------------------------
 # Set functions
 #-----------------------------------------


### PR DESCRIPTION
This PR,
* Adds a new `macos_release_name` special function
* Adds a new `macos_desktop_style` item to set appearance of Dynamic Desktop pictures (i.e. `light`, `dark`, `auto` and `dynamic`) — Closes #3 
* Updates the defaults of `macos_desktop` to the current macOS version's default Dynamic Desktop picture
* Updates the documentation of `macos_desktop` to account for Dynamic Desktop pictures
* Adds `macos_desktop_style` (`light`) to `all`