### PR TITLE
macOS Sonoma updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Also features the `macos_is_dark` helper function to determine if the macOS dark
    * [Extending zsh-lux](#extending-zsh-lux)
        * [Adding items](#adding-items)
        * [Adding modes](#adding-modes)
-   * [Caveats / known issues]()
-       * [macOS Sonoma (14)]()
+   * [Caveats / known issues](#caveats--known-issues)
+       * [macOS Sonoma (14)](#macos-sonoma-14)
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Also features the `macos_is_dark` helper function to determine if the macOS dark
    * [Extending zsh-lux](#extending-zsh-lux)
        * [Adding items](#adding-items)
        * [Adding modes](#adding-modes)
+   * [Caveats / known issues]()
+       * [macOS Sonoma (14)]()
 
 ### Installation
 
@@ -315,6 +317,17 @@ lux iterm purple
 LUX_ITERM_EXTRAS="superhero purple"
 ```
 
+### Caveats / known issues
+
+#### macOS Sonoma (14)
+
+* Using certain HEIF images as desktop picture will cause `macos_desktop_style` to sometimes reset the desktop picture to the system default, Sonoma Horizons (the vineyard photo).
+
+  (This is the case of `System/Library/Desktop Pictures/Sonoma.heic` which is the default used by `macos_desktop` when on Sonoma.)
+
+  **Workaround:** Don't use `macos_desktop_style` with these images. When setting `Sonoma.heic` or any other troublesome image, the image acts as if `macos_desktop_style` was set to  `auto` , i.e. the light/dark of the image will follow the system appearance.
+
+  To use the `all` item, override the `LUX_ALL_LIST` in your shell config to skip `macos_desktop_style` , e.g. `LUX_ALL_LIST=( macos macos_desktop iterm_all vscode )`
 
 ## Fun aliases!
 

--- a/zsh-lux.plugin.zsh
+++ b/zsh-lux.plugin.zsh
@@ -137,7 +137,14 @@ function macos_release_name() {
         "14"    "Sonoma"
     )
     local macos_version=$(sw_vers -productVersion)
-    local macos_release=$_lux_macos_release_names[${macos_version%.*}]
+
+    if [[ "$macos_version" =~ ^10\. ]]; then
+        # macOS 10.*: remove patch version number
+        local macos_release=$_lux_macos_release_names[${macos_version%.*}]
+    else
+        # macOS 11+: remove minor.patch version number
+        local macos_release=$_lux_macos_release_names[${macos_version%.*.*}]
+    fi
 
     _lux_log "fct: $funcstack[1]" "macOS version: $macos_version" \
                                   "macOS release: $macos_release"

--- a/zsh-lux.plugin.zsh
+++ b/zsh-lux.plugin.zsh
@@ -98,6 +98,19 @@ function _lux_command_found() {
     fi
 }
 
+# _lux_file_found: check if file exists
+# * Returns 1 if file does not exist
+# * Echos to stderr with name of calling function
+
+function _lux_file_found() {
+    local file=$1
+    local fct=$funcstack[2]
+    if [[ ! -f "$file" ]]; then
+        echo "'$fct' '$file' not found." >&2
+        return 1
+    fi
+}
+
 #-----------------------------------------
 # Get functions
 #-----------------------------------------
@@ -178,18 +191,31 @@ function _lux_set_macos() {
 #-----------------------------------------
 # Element: 'macos_desktop'
 # Action: Sets macOS desktop picture
-# Default modes:
-#  * 'light': '/System/Library/Desktop Pictures/$(macos_release_name) Graphic.heic'
-#  * 'dark': '/System/Library/Desktop Pictures/$(macos_release_name) Graphic.heic'
+# Default modes
+#  * Sonoma
+#    * 'light': '/System/Library/Desktop Pictures/$(macos_release_name).heic'
+#    * 'dark': '/System/Library/Desktop Pictures/$(macos_release_name).heic'
+#  * All other:
+#    * 'light': '/System/Library/Desktop Pictures/$(macos_release_name) Graphic.heic'
+#    * 'dark': '/System/Library/Desktop Pictures/$(macos_release_name) Graphic.heic'
 # Extra configuration: N/A
 # Requires:
 #  * macOS
 
-_lux_default LUX_MACOS_DESKTOP_LIGHT "/System/Library/Desktop Pictures/$(macos_release_name) Graphic.heic"
-_lux_default LUX_MACOS_DESKTOP_DARK  "/System/Library/Desktop Pictures/$(macos_release_name) Graphic.heic"
+case $(macos_release_name) in
+    "Sonoma")
+        _lux_default LUX_MACOS_DESKTOP_LIGHT "/System/Library/Desktop Pictures/$(macos_release_name).heic"
+        _lux_default LUX_MACOS_DESKTOP_DARK  "/System/Library/Desktop Pictures/$(macos_release_name).heic"
+        ;;
+    *)
+        _lux_default LUX_MACOS_DESKTOP_LIGHT "/System/Library/Desktop Pictures/$(macos_release_name) Graphic.heic"
+        _lux_default LUX_MACOS_DESKTOP_DARK  "/System/Library/Desktop Pictures/$(macos_release_name) Graphic.heic"
+        ;;
+esac
 
 function _lux_set_macos_desktop() {
     if ! _lux_is_macos; then return 1; fi
+    if ! _lux_file_found "$1"; then return 1; fi
     osascript -l JavaScript <<- EOF
         desktops = Application('System Events').desktops()
         for (d in desktops) {


### PR DESCRIPTION
I finally updated to macOS Sonoma (!), and turns some features didn't work well, because of Sonoma's new desktop picture features.

This PR:
* Fixes `macos_release_name`: better support for macOS `10.*` vs `11`+ versions 
* Adds the `_lux_file_found` helper function to validate if a file exists
  * Previously when a non-existing file was used in a JXA (`osascript -l JavaScript`) block, it failed silently
* Adds the `macos_main_version` helper function to compare macOS version numerically
  * Used to check if the macOS version is Sonoma 
* Handles Sonoma's new 'colours' wallpaper location
  * `Sonoma.heic` instead of the previous `<macOS version> Graphic.heic`

Also adds some caveats to the README:
* Notably to skip `macos_desktop_style` when using certain images on Sonoma, i.e. to set in your shell: `LUX_ALL_LIST=( macos macos_desktop iterm_all vscode )`